### PR TITLE
log errors by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - integrate new [mochawesome-report-generator assetsDir feature](https://github.com/adamgruber/mochawesome-report-generator/blob/master/CHANGELOG.md#added-1)
 - rename modules to be more akin to their purpose
 - add first revision of graphQL endpoint
+- log errors always (remove `debug()` wrapper)
 
 ## v4.1.0
 

--- a/bin/_nemo
+++ b/bin/_nemo
@@ -12,7 +12,6 @@ var fs = require('fs');
 var cwd = process.cwd();
 var debug;
 var log;
-var error;
 var server;
 var scaffold;
 var engine;
@@ -53,7 +52,6 @@ scaffold = require('../lib/scaffold');
 engine = require('../lib/engine');
 debug = require('debug');
 log = debug('nemo:log');
-error = debug('nemo:error');
 
 // are we launching the server?
 if (program.server) {
@@ -70,5 +68,5 @@ engine.configure(program)
     return engine.start(configuration);
   })
   .catch(function (err) {
-    error('problem with start %O', err);
+    console.error('problem with start %O', err);
   });

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -4,7 +4,6 @@ var flow = require('../lib/flow');
 var async = require('async');
 var debug = require('debug');
 var log = debug('nemo:engine:log');
-var error = debug('nemo:engine:error');
 var uuidv4 = require('uuid/v4');
 var masterID = uuidv4();
 var Storage = require('./storage');
@@ -13,7 +12,7 @@ module.exports.configure = function configure(program) {
   return Nemo.Configure(program.baseDirectory, {}).then(function (config) {
     return Promise.resolve({program: program, config: config});
   }).catch(function (err) {
-    error('problem with main configuration %O', err);
+    console.error('problem with main configuration %O', err);
   });
 };
 

--- a/lib/flow.js
+++ b/lib/flow.js
@@ -3,7 +3,6 @@
 var merge = require('lodash.merge');
 var debug = require('debug');
 var log = debug('nemo:flow:log');
-var error = debug('nemo:flow:error');
 var filenamify = require('filenamify');
 var reporter = require('../lib/reporter');
 var Glob = require('glob');
@@ -23,7 +22,7 @@ let profile = function profile(cb) {
     var profileObj = this.config.get(`profiles:${profil}`);
     log('profile %s', profil);
     if (!profileObj) {
-      error('profile, profile %s is undefined', profil);
+      console.error('profile, profile %s is undefined', profil);
       return;
     }
     conf = merge({}, base, profileObj || {});

--- a/lib/instance.js
+++ b/lib/instance.js
@@ -6,7 +6,6 @@ module.exports = function instance(input, done, progress) {
   var path = require('path');
   var debug = require('debug');
   var log = debug('nemo:instance:log');
-  var error = debug('nemo:instance:error');
   var startMS;
   var mocha;
   var anyTests = false;
@@ -50,7 +49,6 @@ module.exports = function instance(input, done, progress) {
   };
 
   var defineSuite = function (config) {
-    // console.log(config);
     var nemo;
     var requireFromConfig = input.profile.conf.mocha.require;
     var modulesToRequire = [];
@@ -68,7 +66,7 @@ module.exports = function instance(input, done, progress) {
       try {
         require(module);
       } catch (err) {
-        throw new Error(err);
+        console.error(err);
       }
     });
 
@@ -113,13 +111,13 @@ module.exports = function instance(input, done, progress) {
       try {
         progress(prepareTestResult('pass', test));
       } catch (err) {
-        error(err);
+        console.error(err);
       }
       result.total = result.total + 1;
       result.pass = result.pass + 1;
     });
     runner.on('fail', function (test, err) {
-      error('fail', err);
+      console.error('fail', err);
       progress(prepareTestResult('fail', test, err));
       result.total = result.total + 1;
       result.fail = result.fail + 1;
@@ -144,7 +142,7 @@ module.exports = function instance(input, done, progress) {
             };
             _done();
           }).catch(function (err) {
-            error(err);
+            console.error(err);
             _done(err);
             if (done) {
               done(result);
@@ -185,8 +183,7 @@ module.exports = function instance(input, done, progress) {
     }
   }).then(defineSuite)
     .catch(function (err) {
-      error('error in defineSuite chain');
-      error(err);
+      console.error(err);
       if (done) {
         done(result);
       }

--- a/lib/master.js
+++ b/lib/master.js
@@ -6,7 +6,6 @@ var debug = require('debug');
 var parallelLimit = require('async/parallelLimit');
 var uuid = require('uuid/v4');
 var log = debug('nemo:master:log');
-var error = debug('nemo:master:error');
 var fs = require('fs');
 var table = require('cli-table');
 
@@ -54,7 +53,7 @@ module.exports = function master() {
         })
         .on('progress', progress)
         .on('error', function (er) {
-          error(er);
+          console.error(er);
           thread.kill();
         })
         .on('exit', function () {

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -2,8 +2,6 @@ var debug = require('debug');
 var log = debug('nemo:reporter:log');
 var filenamify = require('filenamify');
 
-// var error = debug('nemo:error');
-
 module.exports.mochawesome = function mochawesome(instance) {
   if (!instance.conf.reports) {
     log('mochawesome: output.reports was not defined. Fallback to manual mochawesome config');

--- a/lib/screenshot.js
+++ b/lib/screenshot.js
@@ -4,7 +4,6 @@ var mkdirp = require('mkdirp');
 var fs = require('fs');
 var debug = require('debug');
 var log = debug('nemo:screenshot:log');
-var error = debug('nemo:screenshot:error');
 var filenamify = require('filenamify');
 
 
@@ -14,7 +13,7 @@ module.exports.setup = (nemo, cb) => {
     var imagePath = arguments[0];
     var screenshotName;
     if (!imagePath && !nemo.runner.context.profile.conf.reports) {
-      error('Trying to capture a screenshot with no path');
+      console.error('Trying to capture a screenshot with no path');
       return Promise.resolve();
     }
     if (!imagePath) {
@@ -51,7 +50,7 @@ module.exports.setup = (nemo, cb) => {
         return p;
       })
       .catch(function (err) {
-        error(`triggered error block: ${err}`);
+        console.error(`triggered error block: ${err}`);
       });
   };
   cb(null);

--- a/lib/server.js
+++ b/lib/server.js
@@ -4,7 +4,6 @@ var graphqlHTTP = require('express-graphql');
 var {buildSchema} = require('graphql');
 var debug = require('debug');
 var log = debug('nemo:server:log');
-var error = debug('nemo:server:error');
 
 var schema = buildSchema(`
     type Query {
@@ -64,7 +63,7 @@ module.exports = (program) => {
 
     })
     .catch(err => {
-      error(err);
+      console.error(err);
     });
 
 

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -2,7 +2,6 @@ const CircularJSON = require('circular-json');
 var Influx = require('influx');
 var debug = require('debug');
 var log = debug('nemo:storage:log');
-var errord = debug('nemo:storage:error');
 
 let Storage = function (prefontaine) {
   this.prefontaine = prefontaine;
@@ -116,7 +115,7 @@ Storage.prototype.lifecycle = function (result) {
       fields: { event, duration, threadID, masterID }
     }
   ]).catch(err => {
-    errord(`Error saving data to InfluxDB! ${err.stack}`);
+    console.error(`Error saving data to InfluxDB! ${err.stack}`);
   });
 };
 


### PR DESCRIPTION
This PR is a suggestion to log errors all of the time.

Use `debug()` for extraneous logs that are only sometimes helpful. Logs about errors that occur are always helpful to the user and should not be swallowed except for in rare cases.

More thoughts:
- users shouldn't have to remember extra environment variables
- failing silently doesn't indicate an error and is a frustrating user experience (especially on CI where it is sometimes non-trivial to change job configuration)