### PR TITLE
Allow unknown command line arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .idea
 test/report
 scaffold/report
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## UNRELEASED
+- add `-U` or `--allow-unknown-args` to prevent Nemo from validating CLI arguments
+
 ## 4.2.1
 
 - modify scaffold to favor CLI arg -L over env variable in config

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ By default, Nemo will not accept CLI arguments that are not listed under [CLI Ar
 
 Custom arguments can be useful for programmatically customizing Nemo configuration.  
 
-Use `--U` or `--allow-unknown-args` to prevent Nemo from validating CLI arguments
+Use `-U` or `--allow-unknown-args` to prevent Nemo from validating CLI arguments
 
 ```sh
 $ ./bin/nemo -U --myCustomArg myValue --anotherArg

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ $ ./bin/nemo --help
     -S, --server                 run the nemo web server
     -L, --logging                info level logging (errors log by default)
     -X, --scaffold <path>        inject an example nemo suite under <path>
+    -U, --allow-unknown-args     allow command line arguments not specified by Nemo
     --debug-brk                  enable node's debugger breaking on the first line
     --inspect                    activate devtools in chrome
     --no-timeouts                remove timeouts in debug/inspect use case
@@ -268,3 +269,15 @@ You should add this to the `"mocha"` property within `"profiles"` of `config.jso
 ```
 
 `nemo` creates `mocha` instances programmatically. Unfortunately, not all `mocha` command line options are available when instantiating it this way. One of the arguments that is **not** supported is the `--require` flag, which useful if you want to `require` a module, e.g. `babel-register` for transpilation. Thus, we added a `"require"` property in `config.json`, which takes a string of a single npm module name, or an array of npm module names. If it is an array, `nemo` will `require` each one before instantiating the `mocha` instances.
+
+## Custom CLI Options
+
+By default, Nemo will not accept CLI arguments that are not listed under [CLI Arguments](#cli-arguments) 
+
+Custom arguments can be useful for programmatically customizing Nemo configuration.  
+
+Use `--U` or `--allow-unknown-args` to prevent Nemo from validating CLI arguments
+
+```sh
+$ ./bin/nemo -U --myCustomArg myValue --anotherArg
+```

--- a/bin/_nemo
+++ b/bin/_nemo
@@ -24,6 +24,8 @@ function cwdPath(rel) {
   return path.resolve(cwd, rel);
 }
 
+var allowUnknownArgs = (process.argv.indexOf('-U') > -1) || (process.argv.indexOf('--allow-unknown-args') > -1);
+
 program
   .version(JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8')).version)
   .usage('[options]')
@@ -35,9 +37,11 @@ program
   .option('-S, --server ', 'run the nemo web server')
   .option('-L, --logging ', 'info level logging (errors log by default)')
   .option('-X, --scaffold <path>', 'inject an example nemo suite under <path>')
+  .option('-U, --allow-unknown-args', 'allow command line arguments not specified by Nemo')
   .option('--debug-brk', 'enable node\'s debugger breaking on the first line')
   .option('--inspect', 'activate devtools in chrome')
   .option('--no-timeouts', 'remove timeouts in debug/inspect use case')
+  .allowUnknownOption(allowUnknownArgs)
   .parse(process.argv);
 
 program._name = 'nemo';
@@ -52,6 +56,10 @@ scaffold = require('../lib/scaffold');
 engine = require('../lib/engine');
 debug = require('debug');
 log = debug('nemo:log');
+
+if(allowUnknownArgs) {
+  log('allowing unknown command line arguments');
+}
 
 // are we launching the server?
 if (program.server) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nemo",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1496,9 +1496,9 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mkdirp": {
       "version": "0.5.1",
@@ -1506,6 +1506,13 @@
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+        }
       }
     },
     "mocha": {
@@ -2428,11 +2435,6 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
       "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
     },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -2452,6 +2454,11 @@
           }
         }
       }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "strip-ansi": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nemo",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "description": "Wrapper to run mocha suites with injected selenium-webdriver instance",
   "main": "index.js",
   "scripts": {
@@ -17,6 +17,7 @@
     "nemo:form": "SELENIUM_PROMISE_MANAGER=0 ./bin/nemo -B test -P form",
     "nemo:xunit": "./bin/nemo -B test -G @suite1 -P xunit",
     "nemo:server": "./bin/nemo -B test -S",
+    "nemo:dynamic": "./bin/nemo -B test -U --url-from-cli 'https://www.wikipedia.org' -P dynamic",
     "nemo:scaffold": "./bin/nemo -B scaffold -P pay,search,form",
     "lint": "eslint ./bin/* ./lib/*"
   },
@@ -59,6 +60,7 @@
     "graphql": "^0.11.7",
     "influx": "^5.0.7",
     "lodash.merge": "^4.6.1",
+    "minimist": "^1.2.0",
     "mocha": "^4",
     "mochawesome": "^3.0.2",
     "moment": "^2.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nemo",
-  "version": "4.2.3",
+  "version": "4.2.2",
   "description": "Wrapper to run mocha suites with injected selenium-webdriver instance",
   "main": "index.js",
   "scripts": {

--- a/test/config/config.json
+++ b/test/config/config.json
@@ -127,6 +127,7 @@
                 "browser": "phantomjs"
                 //just pretending this is another browser :)
             }
-        }
+        },
+        "dynamic": "exec:./config/dynamic"
     }
 }

--- a/test/config/dynamic.js
+++ b/test/config/dynamic.js
@@ -1,0 +1,19 @@
+const path = require('path');
+const assert = require('assert');
+const minimist = require('minimist');
+
+module.exports = function () {
+  // run tests if running nemo:dynamic npm script
+  var argv = minimist(process.argv.slice(2));
+  if(argv['url-from-cli']) {
+    assert.equal(argv.U, true, '-U not specified as expected');
+    assert.equal(argv['url-from-cli'], 'https://www.wikipedia.org', 'urlFromCli should equal to https://www.wikipedia.org');
+  }
+
+  return {
+    tests: path.resolve(__dirname, '../dynamic.js'),
+    data: {
+      urlFromCli: argv['url-from-cli']
+    }
+  };
+};

--- a/test/dynamic.js
+++ b/test/dynamic.js
@@ -1,0 +1,10 @@
+const assert = require('assert');
+
+describe('@dynamic@', function () {
+  it('should run quickly', async function () {
+    let nemo = this.nemo;
+    let {baseUrl, urlFromCli} = nemo.data;
+    assert.equal(nemo.data.urlFromCli, 'https://www.wikipedia.org', 'urlFromCli should equal to https://www.wikipedia.org');
+    await nemo.driver.get(urlFromCli || baseUrl);
+  });
+});


### PR DESCRIPTION
## Custom CLI Options

By default, Nemo will not accept CLI arguments that are not listed under [CLI Arguments](#cli-arguments) 

Custom arguments can be useful for programmatically customizing Nemo configuration.  

Use `-U` or `--allow-unknown-args` to prevent Nemo from validating CLI arguments

```sh
$ ./bin/nemo -U --myCustomArg myValue --anotherArg
``` 
## Testing
`npm run nemo:dynamic`