### PR TITLE
Fix.aftereach.context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## UNRELEASED
+
+- fix driverPerTest: true afterEach context so driver will quit
+
 ## 4.4.0
 
 - add `<profile>.driverPerTest`

--- a/lib/runner/mocha.js
+++ b/lib/runner/mocha.js
@@ -41,6 +41,7 @@ function MochaRunner(runnerConfig) {
   }
 
   function destroyNemo() {
+    log('destroyNemo: called');
     if (this.nemo) {
       return this.nemo.driver.quit()
         .then(function () {
@@ -62,7 +63,7 @@ function MochaRunner(runnerConfig) {
           .then(bindNemo.bind(this));
       });
       Suite._beforeEach.unshift(Suite._beforeEach.pop());
-      Suite.afterEach(destroyNemo.bind(this));
+      Suite.afterEach(destroyNemo);
       return;
     }
     // createNemo beforeAll (one nemo per suite)


### PR DESCRIPTION
driver was not quitting afterEach when `driverPerTest` was set to `true`