### PR TITLE
Refactor - lib/flow

### DIFF
--- a/docs/relationships.md
+++ b/docs/relationships.md
@@ -1,0 +1,5 @@
+# Relationships
+
+## Between nemo.js and flow.js
+
+nemo.js imports functions from flow.js and binds them with configuration received in `start()`.

--- a/lib/flow.js
+++ b/lib/flow.js
@@ -83,11 +83,11 @@ const glob = function glob(cb) {
   this.instances.forEach(function (instance, index, arr) {
     let testFileGlob = path.resolve(this.program.baseDirectory, instance.conf.tests);
     Glob(testFileGlob, {}, function (err, files) {
-      let _instance = merge({}, instance);
       log('glob, #files %d', files.length);
       if (err) {
         return cb(err);
       }
+      let _instance = merge({}, instance);
       _instance.conf.tests = files;
       instances.push(_instance);
       if (index === arr.length - 1) {
@@ -99,6 +99,8 @@ const glob = function glob(cb) {
   }.bind(this));
 };
 
+const removeFileExtension = filename => filename.endsWith('.js') ? filename.substr(0, filename.length - 3) : filename;
+
 const pfile = function pfile(cb) {
   let base = this.config.get('profiles:base');
   let instances = [];
@@ -109,9 +111,7 @@ const pfile = function pfile(cb) {
       files.forEach(function (file) {
         let _instance;
         let justFile = file.split(this.program.baseDirectory)[1];
-        justFile = filenamify(justFile);
-        // remove file ext
-        justFile = (justFile.endsWith('.js')) ? justFile.substr(0, justFile.length - 3) : justFile;
+        justFile = removeFileExtension(filenamify(justFile));
         log('pfile, file %s', justFile);
         _instance = merge({}, instance);
         _instance.conf.tests = [file];
@@ -165,21 +165,22 @@ const pdata = function pdata(cb) {
   cb(null, this);
 };
 
+const setupReporterOptions = (self, instance) => {
+  let reporterFromConfig = instance.conf.mocha.reporter;
+  if (reporter.hasOwnProperty(reporterFromConfig)) {
+    log(`reportFiles: we have a handler for ${reporterFromConfig}`);
+    reporter[reporterFromConfig](self, instance);
+  }
+  return instance;
+};
+
 const reportFiles = function reportFiles(cb) {
   log('reportFiles:start');
-  let instances = [];
-  // let reporterFromConfig = this.config.get('profiles:base:mocha:reporter');
-  this.instances.forEach(function (instance) {
-    let reporterFromConfig = instance.conf.mocha.reporter;
-    // set up reporter options
-    if (reporter.hasOwnProperty(reporterFromConfig)) {
-      log(`reportFiles: we have a handler for ${reporterFromConfig}`);
-      reporter[reporterFromConfig](this, instance);
-    }
-    instances.push(instance);
+  this.instances = this.instances.map(function (instance) {
+    return setupReporterOptions(this, instance);
   }.bind(this));
-  this.instances = instances;
   cb(null, this);
 };
 
+/* These functions get flow.map(fn => fn.bind(Nemo)) in nemo.js */
 module.exports = [profile, reportDir, grep, glob, pfile, pdata, reportFiles];


### PR DESCRIPTION
Tests pass. However I am not sure about the code correctness; I have double check. Please take a deeper look. Here's the test report:

```
$ npm run test

> nemo@4.7.0 test /Code/github/krakenjs/nemo
> npm run lint && node test/test-helper clean && npm run nemo && npm run nemo:parallel && npm run nemo:lifecycle:suite && npm run nemo:lifecycle:test && node test/test-helper verify


> nemo@4.7.0 lint /Code/github/krakenjs/nemo
> eslint ./bin/* ./lib/*


/Code/github/krakenjs/nemo/lib/flow.js
  35:13  warning  There should be no space after '{'   object-curly-spacing
  35:31  warning  There should be no space before '}'  object-curly-spacing

✖ 2 problems (0 errors, 2 warnings)

deleted report directory

> nemo@4.7.0 nemo /Code/github/krakenjs/nemo
> SELENIUM_PROMISE_MANAGER=0 ./bin/nemo -B test



  @suite1@suite2@suite3@suite4@
ç^C
> nemo@4.7.0 nemo:parallel /Code/github/krakenjs/nemo
> ./bin/nemo -B test -G @suite1,@suite2,@suite3,@suite4 -F

^CTerminated: 15
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────


/Code/github/krakenjs/nemo 2018-10-19 21:31:44 1539964904. Its October yo!
nemo (master)
$ npm run test

> nemo@4.7.0 test /Code/github/krakenjs/nemo
> npm run lint && node test/test-helper clean && npm run nemo && npm run nemo:parallel && npm run nemo:lifecycle:suite && npm run nemo:lifecycle:test && node test/test-helper verify


> nemo@4.7.0 lint /Code/github/krakenjs/nemo
> eslint ./bin/* ./lib/*

deleted report directory

> nemo@4.7.0 nemo /Code/github/krakenjs/nemo
> SELENIUM_PROMISE_MANAGER=0 ./bin/nemo -B test



  @suite1@suite2@suite3@suite4@
    ✓ may fail a few times1 (5088ms)
user event listener: test may fail a few times1 status: passed
    @inner@
      ✓ may fail a few times2 (2745ms)
user event listener: test may fail a few times2 status: passed

  @suite1.2@suite2.2@suite3.2@suite4.2@
    ✓ may fail a few times3 (3256ms)
user event listener: test may fail a few times3 status: passed
    @inner@
      ✓ may fail a few times4 (2661ms)
user event listener: test may fail a few times4 status: passed


  4 passing (16s)

[mochawesome] Report JSON saved to /Code/github/krakenjs/nemo/test/report/10-19-2018/21-32-15/profile!base/nemo-report.json

[mochawesome] Report HTML saved to /Code/github/krakenjs/nemo/test/report/10-19-2018/21-32-15/profile!base/nemo-report.html

┌────────────────────────────────────────────────────────────────┬──────┬──────┬───────┐
│ tags                                                           │ pass │ fail │ total │
├────────────────────────────────────────────────────────────────┼──────┼──────┼───────┤
│ profile: base                                                  │ 4    │ 0    │ 4     │
│ reportFile: /10-19-2018/21-32-15/profile!base/nemo-report.html │      │      │       │
│                                                                │      │      │       │
├────────────────────────────────────────────────────────────────┼──────┼──────┼───────┤
│ TOTALS                                                         │ 4    │ 0    │ 4     │
└────────────────────────────────────────────────────────────────┴──────┴──────┴───────┘

> nemo@4.7.0 nemo:parallel /Code/github/krakenjs/nemo
> ./bin/nemo -B test -G @suite1,@suite2,@suite3,@suite4 -F



  @suite1@suite2@suite3@suite4@




  @suite1@suite2@suite3@suite4@
  @suite1.2@suite2.2@suite3.2@suite4.2@


  @suite1@suite2@suite3@suite4@


  @suite1.2@suite2.2@suite3.2@suite4.2@


  @suite1.2@suite2.2@suite3.2@suite4.2@


  @suite1@suite2@suite3@suite4@


  @suite1.2@suite2.2@suite3.2@suite4.2@
    ✓ may fail a few times3 (3870ms)
    @inner@
    ✓ may fail a few times3 (3934ms)
user event listener: test may fail a few times3 status: passed
    @inner@
    ✓ may fail a few times3 (3688ms)
user event listener: test may fail a few times3 status: passed
    @inner@
user event listener: test may fail a few times3 status: passed
    ✓ may fail a few times1 (4001ms)
    @inner@
user event listener: test may fail a few times1 status: passed
    ✓ may fail a few times3 (3928ms)
    @inner@
user event listener: test may fail a few times3 status: passed
    ✓ may fail a few times1 (3898ms)
    @inner@
user event listener: test may fail a few times1 status: passed
    ✓ may fail a few times1 (4225ms)
    @inner@
user event listener: test may fail a few times1 status: passed
    ✓ may fail a few times1 (4493ms)
    @inner@
user event listener: test may fail a few times1 status: passed
      ✓ may fail a few times2 (5368ms)


  2 passing (11s)

user event listener: test may fail a few times2 status: passed
[mochawesome] Report JSON saved to /Code/github/krakenjs/nemo/test/report/10-19-2018/21-32-33/profile!base!grep!@suite2!file!nested/nemo-report.json

[mochawesome] Report HTML saved to /Code/github/krakenjs/nemo/test/report/10-19-2018/21-32-33/profile!base!grep!@suite2!file!nested/nemo-report.html

      ✓ may fail a few times4 (5535ms)
      ✓ may fail a few times2 (5059ms)
      ✓ may fail a few times2 (4902ms)

      ✓ may fail a few times2 (5147ms)



  2 passing (11s)



  2 passing (11s)

  2 passing (11s)

user event listener: test may fail a few times4 status: passed

user event listener: test may fail a few times2 status: passed
      ✓ may fail a few times4 (4559ms)


  2 passing (11s)


  2 passing (11s)

      ✓ may fail a few times4 (5626ms)


  2 passing (11s)

[mochawesome] Report JSON saved to /Code/github/krakenjs/nemo/test/report/10-19-2018/21-32-33/profile!base!grep!@suite1!file!nested2/nemo-report.json

[mochawesome] Report HTML saved to /Code/github/krakenjs/nemo/test/report/10-19-2018/21-32-33/profile!base!grep!@suite1!file!nested2/nemo-report.html

user event listener: test may fail a few times2 status: passed
[mochawesome] Report JSON saved to /Code/github/krakenjs/nemo/test/report/10-19-2018/21-32-33/profile!base!grep!@suite3!file!nested/nemo-report.json

[mochawesome] Report HTML saved to /Code/github/krakenjs/nemo/test/report/10-19-2018/21-32-33/profile!base!grep!@suite3!file!nested/nemo-report.html

[mochawesome] Report JSON saved to /Code/github/krakenjs/nemo/test/report/10-19-2018/21-32-33/profile!base!grep!@suite4!file!nested/nemo-report.json

[mochawesome] Report HTML saved to /Code/github/krakenjs/nemo/test/report/10-19-2018/21-32-33/profile!base!grep!@suite4!file!nested/nemo-report.html

[mochawesome] Report JSON saved to /Code/github/krakenjs/nemo/test/report/10-19-2018/21-32-33/profile!base!grep!@suite1!file!nested/nemo-report.json

[mochawesome] Report HTML saved to /Code/github/krakenjs/nemo/test/report/10-19-2018/21-32-33/profile!base!grep!@suite1!file!nested/nemo-report.html

[mochawesome] Report JSON saved to /Code/github/krakenjs/nemo/test/report/10-19-2018/21-32-33/profile!base!grep!@suite4!file!nested2/nemo-report.json

[mochawesome] Report HTML saved to /Code/github/krakenjs/nemo/test/report/10-19-2018/21-32-33/profile!base!grep!@suite4!file!nested2/nemo-report.html

[mochawesome] Report JSON saved to /Code/github/krakenjs/nemo/test/report/10-19-2018/21-32-33/profile!base!grep!@suite3!file!nested2/nemo-report.json

[mochawesome] Report HTML saved to /Code/github/krakenjs/nemo/test/report/10-19-2018/21-32-33/profile!base!grep!@suite3!file!nested2/nemo-report.html

user event listener: test may fail a few times2 status: passed
user event listener: test may fail a few times4 status: passed
user event listener: test may fail a few times4 status: passed
      ✓ may fail a few times4 (5789ms)


  2 passing (11s)

[mochawesome] Report JSON saved to /Code/github/krakenjs/nemo/test/report/10-19-2018/21-32-33/profile!base!grep!@suite2!file!nested2/nemo-report.json

[mochawesome] Report HTML saved to /Code/github/krakenjs/nemo/test/report/10-19-2018/21-32-33/profile!base!grep!@suite2!file!nested2/nemo-report.html

user event listener: test may fail a few times4 status: passed
┌──────────────────────────────────────────────────────────────────────────────────────────┬──────┬──────┬───────┐
│ tags                                                                                     │ pass │ fail │ total │
├──────────────────────────────────────────────────────────────────────────────────────────┼──────┼──────┼───────┤
│ profile: base                                                                            │ 2    │ 0    │ 2     │
│ grep: @suite2                                                                            │      │      │       │
│ file: nested                                                                             │      │      │       │
│ reportFile: /10-19-2018/21-32-33/profile!base!grep!@suite2!file!nested/nemo-report.html  │      │      │       │
│                                                                                          │      │      │       │
├──────────────────────────────────────────────────────────────────────────────────────────┼──────┼──────┼───────┤
│ profile: base                                                                            │ 2    │ 0    │ 2     │
│ grep: @suite1                                                                            │      │      │       │
│ file: nested2                                                                            │      │      │       │
│ reportFile: /10-19-2018/21-32-33/profile!base!grep!@suite1!file!nested2/nemo-report.html │      │      │       │
│                                                                                          │      │      │       │
├──────────────────────────────────────────────────────────────────────────────────────────┼──────┼──────┼───────┤
│ profile: base                                                                            │ 2    │ 0    │ 2     │
│ grep: @suite3                                                                            │      │      │       │
│ file: nested                                                                             │      │      │       │
│ reportFile: /10-19-2018/21-32-33/profile!base!grep!@suite3!file!nested/nemo-report.html  │      │      │       │
│                                                                                          │      │      │       │
├──────────────────────────────────────────────────────────────────────────────────────────┼──────┼──────┼───────┤
│ profile: base                                                                            │ 2    │ 0    │ 2     │
│ grep: @suite4                                                                            │      │      │       │
│ file: nested                                                                             │      │      │       │
│ reportFile: /10-19-2018/21-32-33/profile!base!grep!@suite4!file!nested/nemo-report.html  │      │      │       │
│                                                                                          │      │      │       │
├──────────────────────────────────────────────────────────────────────────────────────────┼──────┼──────┼───────┤
│ profile: base                                                                            │ 2    │ 0    │ 2     │
│ grep: @suite1                                                                            │      │      │       │
│ file: nested                                                                             │      │      │       │
│ reportFile: /10-19-2018/21-32-33/profile!base!grep!@suite1!file!nested/nemo-report.html  │      │      │       │
│                                                                                          │      │      │       │
├──────────────────────────────────────────────────────────────────────────────────────────┼──────┼──────┼───────┤
│ profile: base                                                                            │ 2    │ 0    │ 2     │
│ grep: @suite3                                                                            │      │      │       │
│ file: nested2                                                                            │      │      │       │
│ reportFile: /10-19-2018/21-32-33/profile!base!grep!@suite3!file!nested2/nemo-report.html │      │      │       │
│                                                                                          │      │      │       │
├──────────────────────────────────────────────────────────────────────────────────────────┼──────┼──────┼───────┤
│ profile: base                                                                            │ 2    │ 0    │ 2     │
│ grep: @suite4                                                                            │      │      │       │
│ file: nested2                                                                            │      │      │       │
│ reportFile: /10-19-2018/21-32-33/profile!base!grep!@suite4!file!nested2/nemo-report.html │      │      │       │
│                                                                                          │      │      │       │
├──────────────────────────────────────────────────────────────────────────────────────────┼──────┼──────┼───────┤
│ profile: base                                                                            │ 2    │ 0    │ 2     │
│ grep: @suite2                                                                            │      │      │       │
│ file: nested2                                                                            │      │      │       │
│ reportFile: /10-19-2018/21-32-33/profile!base!grep!@suite2!file!nested2/nemo-report.html │      │      │       │
│                                                                                          │      │      │       │
├──────────────────────────────────────────────────────────────────────────────────────────┼──────┼──────┼───────┤
│ TOTALS                                                                                   │ 16   │ 0    │ 16    │
└──────────────────────────────────────────────────────────────────────────────────────────┴──────┴──────┴───────┘

> nemo@4.7.0 nemo:lifecycle:suite /Code/github/krakenjs/nemo
> SELENIUM_PROMISE_MANAGER=0 ./bin/nemo -B test -P driverPerSuite



  Nemo Instance for @entireSuite@
    ✓ should pass (2435ms)
user event listener: test should pass status: passed


  1 passing (3s)

[mochawesome] Report JSON saved to /Code/github/krakenjs/nemo/test/report/10-19-2018/21-32-46/profile!driverPerSuite/nemo-report.json

[mochawesome] Report HTML saved to /Code/github/krakenjs/nemo/test/report/10-19-2018/21-32-46/profile!driverPerSuite/nemo-report.html

┌──────────────────────────────────────────────────────────────────────────┬──────┬──────┬───────┐
│ tags                                                                     │ pass │ fail │ total │
├──────────────────────────────────────────────────────────────────────────┼──────┼──────┼───────┤
│ profile: driverPerSuite                                                  │ 1    │ 0    │ 1     │
│ reportFile: /10-19-2018/21-32-46/profile!driverPerSuite/nemo-report.html │      │      │       │
│                                                                          │      │      │       │
├──────────────────────────────────────────────────────────────────────────┼──────┼──────┼───────┤
│ TOTALS                                                                   │ 1    │ 0    │ 1     │
└──────────────────────────────────────────────────────────────────────────┴──────┴──────┴───────┘

> nemo@4.7.0 nemo:lifecycle:test /Code/github/krakenjs/nemo
> SELENIUM_PROMISE_MANAGER=0 ./bin/nemo -B test -P driverPerTest



  Nemo Instance for @eachTest@
    ✓ should pass (3225ms)
user event listener: test should pass status: passed


  1 passing (4s)

[mochawesome] Report JSON saved to /Code/github/krakenjs/nemo/test/report/10-19-2018/21-32-51/profile!driverPerTest/nemo-report.json

[mochawesome] Report HTML saved to /Code/github/krakenjs/nemo/test/report/10-19-2018/21-32-51/profile!driverPerTest/nemo-report.html

┌─────────────────────────────────────────────────────────────────────────┬──────┬──────┬───────┐
│ tags                                                                    │ pass │ fail │ total │
├─────────────────────────────────────────────────────────────────────────┼──────┼──────┼───────┤
│ profile: driverPerTest                                                  │ 1    │ 0    │ 1     │
│ reportFile: /10-19-2018/21-32-51/profile!driverPerTest/nemo-report.html │      │      │       │
│                                                                         │      │      │       │
├─────────────────────────────────────────────────────────────────────────┼──────┼──────┼───────┤
│ TOTALS                                                                  │ 1    │ 0    │ 1     │
└─────────────────────────────────────────────────────────────────────────┴──────┴──────┴───────┘
verifying 4 master level run folders
verifying 4 instance level summary.json files
verifying 11 instance level run folders
verifying 22 instance level nemo-report* files
verifying 10 screen capture png files
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
```