### PR TITLE
add switch for zeroExitCode even for failing tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,12 @@ mocha options. described elsewhere
 
 any environment variables you want in the test process.
 
+### `base.zeroExitCode`
+
+-if set to true, nemo will always exit with zero code 
+-if set to false, or don't set any value, the exitCode is Math.min(output.totals.fail, 255);
+
+
 NOTES:
 - currently `base.env` is only honored if nemo is launching parallel nemo instances (each as its own process).
 If nemo launches a single nemo instance in the main process, these are ignored.

--- a/config/cli/config/listeners.js
+++ b/config/cli/config/listeners.js
@@ -20,7 +20,9 @@ module.exports = [{
     });
     tabl.push(['TOTALS', output.totals.pass, output.totals.fail, output.totals.total]);
     console.log(tabl.toString());
-    process.exitCode = Math.min(output.totals.fail, 255);
+    
+    let zeroExitCode = context.config.get('profiles:base:zeroExitCode') || false
+    process.exitCode = zeroExitCode ? 0 : Math.min(output.totals.fail, 255);
     if (context.program.exit) {
       process.exit();
     }

--- a/lib/console.js
+++ b/lib/console.js
@@ -19,7 +19,9 @@ module.exports = function (context, instances) {
   table.push(...getTableRows(output));
   table.push(['TOTALS', output.totals.pass, output.totals.fail, output.totals.total]);
   console.log(table.toString());
-  process.exitCode = Math.min(output.totals.fail, 255);
+  
+  let zeroExitCode = context.config.get('profiles:base:zeroExitCode') || false
+  process.exitCode = zeroExitCode ? 0 : Math.min(output.totals.fail, 255);
   if (context.program.exit) {
     process.exit();
   }


### PR DESCRIPTION
user can just add below setting to profile:base **"zeroExitCode": true,** to enable always zeroExitCode for nemo.