### PR TITLE
Skip creating nemo instance when suite has empty tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 4.11.1
 
 - fix type error that is causing when describe.skip is used (https://github.com/krakenjs/nemo/pull/75)
+- skip creating nemo instance when suite has empty tests  (https://github.com/krakenjs/nemo/pull/76)
 
 ## 4.11.0
 

--- a/lib/runner/mocha.js
+++ b/lib/runner/mocha.js
@@ -83,8 +83,11 @@ function MochaRunner(runnerConfig) {
     if (instanceConfig.profile.conf.driverPerTest) {
       log('driverPerTest %s', instanceConfig.profile.conf.driverPerTest);
       Suite.beforeEach(function () {
-        return createNemo()
-          .then(bindNemo.bind(this));
+        if (Suite.tests.length > 0) {
+          return createNemo()
+            .then(bindNemo.bind(this));
+        }
+        return;
       });
       if (Suite._beforeEach.length > 0) {
         Suite._beforeEach.unshift(Suite._beforeEach.pop());
@@ -94,8 +97,11 @@ function MochaRunner(runnerConfig) {
     }
     // createNemo beforeAll (one nemo per suite)
     Suite.beforeAll(function () {
-      return createNemo()
-        .then(bindNemo.bind(this));
+      if (Suite.tests.length > 0) {
+        return createNemo()
+          .then(bindNemo.bind(this));
+      }
+      return;
     });
 
     if (Suite._beforeAll.length > 0) {


### PR DESCRIPTION
This is to skip creating `nemo`  instance when Suite has empty tests. 

```
describe('@LOGIN_TESTS@', function () {
   context('when user doesn't have account', function () {
       it('should not allow user to login', function() {
          // test goes here
      });
   })
})

```

The above test will create only one instance 